### PR TITLE
Make rust-carball build on non-win OSes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,15 @@ indicatif = "0.16.2"
 polars = {version = "0.16.0", features = ["dtype-u8", "parquet"]}
 ndarray = "0.15.3"
 ndarray-stats = "0.5.0"
-chip = "0.0.6"
+chip = { version = "0.0.6", optional = true }
 nalgebra = "0.18.1"
 thiserror = "1.0.30"
 structopt = "0.3.22"
 clap = "2.33.3"
+
+[features]
+ball_prediction = ["dep:chip"]
+default = ["ball_prediction"]
 
 [dependencies.pyo3]
 version = "0.14.1"
@@ -35,4 +39,5 @@ name = "bench_parsing"
 harness = false
 
 [profile.release] 
+lto = true
 debug = true

--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ It tends to be faster to compile for release and parse as opposed to compiling f
 
 To read logs when running tests:
 `cargo test -- --nocapture`
+
+#### Building without RLUtilities (required to build on Linux or macOS)
+
+If you want to build without RLUtilities, perhaps because you're running `rust-carball` on Linux or macOS, run `cargo build` with the `--no-default-features`. Unfortunately this will come at the cost of disabling ball prediction analysis.
+
+This is necessary for Linux and macOS because the `ball_prediction` feature (enabled by default) makes use of `[RLUtilities](https://github.com/samuelpmish/RLUtilities)` via the `[chip](https://github.com/whatisaphone/chip)` crate. Unfortunately `chip` doesn't build `RLUtilities` directly, and the version of `RLUtilities` that `chip` depends on will only build on Windows.

--- a/src/analysis/hit.rs
+++ b/src/analysis/hit.rs
@@ -1,5 +1,7 @@
 use crate::actor_handlers::{TimeSeriesBallData, TimeSeriesCarData, WrappedUniqueId};
+#[cfg(feature = "ball_prediction")]
 use crate::analysis::{predict_ball_bounce, BallPredictionError};
+
 use crate::frame_parser::FrameParser;
 use crate::outputs::MetadataOutput;
 use log::{error, warn};
@@ -29,6 +31,7 @@ pub struct Hit {
 pub struct HitDebugInfo {
     pub hit_team_num_changed: bool,
     pub ang_vel_changed: bool,
+    #[cfg(feature = "ball_prediction")]
     pub predicted_bounce: bool,
     pub speed_increased: bool,
 }
@@ -70,6 +73,7 @@ impl Hit {
                                 // Detect hits
                                 let mut hit_team_num_changed = false;
                                 let mut ang_vel_changed = false;
+                                #[cfg(feature = "ball_prediction")]
                                 let mut predicted_bounce = false;
                                 let mut speed_increased = false;
 
@@ -98,6 +102,7 @@ impl Hit {
                                     .ok_or(HitDetectionError::MissingDelta(frame_number))?
                                     .delta;
                                 {
+                                    #[cfg(feature = "ball_prediction")]
                                     if predict_ball_bounce(previous_frame_ball_data_value, delta)
                                         .map_err(HitDetectionError::BallPredictionError)?
                                     {
@@ -140,6 +145,7 @@ impl Hit {
                                         } else {
                                             // No definite conclusion here
                                             // hit_team_num did not change, speed did not increase, but ang_vel changed
+                                            #[cfg(feature = "ball_prediction")]
                                             if !predicted_bounce {
                                                 // Look at nearest car distance.
                                                 is_hit = IsHitConclusion::PossibleHit;
@@ -203,6 +209,7 @@ impl Hit {
                                                         _debug_info: HitDebugInfo {
                                                             hit_team_num_changed,
                                                             ang_vel_changed,
+                                                            #[cfg(feature = "ball_prediction")]
                                                             predicted_bounce,
                                                             speed_increased,
                                                         },
@@ -223,6 +230,7 @@ impl Hit {
                                                         _debug_info: HitDebugInfo {
                                                             hit_team_num_changed,
                                                             ang_vel_changed,
+                                                            #[cfg(feature = "ball_prediction")]
                                                             predicted_bounce,
                                                             speed_increased,
                                                         },
@@ -301,6 +309,7 @@ fn unwrap_ang_vel(ball_data: &TimeSeriesBallData) -> Option<(f32, f32, f32)> {
 
 #[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HitDetectionError {
+    #[cfg(feature = "ball_prediction")]
     #[error("ball prediction failed: {0}")]
     BallPredictionError(BallPredictionError),
     #[error("missing delta from parsed replay on frame {0}")]

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,10 +1,15 @@
 pub mod analyzer;
+
+#[cfg(feature = "ball_prediction")]
 pub mod ball_prediction;
+
 pub mod gameplay_period;
 pub mod hit;
 pub mod stats;
 
 pub use self::analyzer::*;
+
+#[cfg(feature = "ball_prediction")]
 pub use self::ball_prediction::*;
 pub use self::gameplay_period::*;
 pub use self::hit::*;


### PR DESCRIPTION
In order to avoid a breaking change for windows users, building on non-win OSes requires passing the `--no-default-features` flag.